### PR TITLE
Intelligent retry

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -1204,8 +1204,11 @@ def extract_item_features_api(request: HttpRequest) -> JsonResponse:
     except ImageValidationError as validation_error:
         logger.warning("[ExtractAPI] Image validation error: %s", validation_error)
         return JsonResponse({"error": str(validation_error)}, status=400)
-    except OutputParserException:
-        logger.warning("[ExtractAPI] LLM failed to produce valid structured output after all attempts")
+    except OutputParserException as parser_error:
+        logger.exception(
+            "[ExtractAPI] LLM failed to produce valid structured output after all attempts: %s",
+            parser_error,
+        )
         return JsonResponse({"error": "Failed to process image"}, status=500)
     except Exception:
         logger.exception("[ExtractAPI] Exception during extraction")

--- a/core/views.py
+++ b/core/views.py
@@ -15,6 +15,7 @@ from django.db.models import Count, F
 from django.db.models.functions import Greatest
 from django.http import Http404, HttpRequest, HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
+from langchain_core.exceptions import OutputParserException
 from PIL import Image, UnidentifiedImageError
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
@@ -1202,6 +1203,9 @@ def extract_item_features_api(request: HttpRequest) -> JsonResponse:
     except ImageValidationError as validation_error:
         logger.warning("[ExtractAPI] Image validation error: %s", validation_error)
         return JsonResponse({"error": str(validation_error)}, status=400)
+    except OutputParserException:
+        logger.warning("[ExtractAPI] LLM failed to produce valid structured output after all attempts")
+        return JsonResponse({"error": "Failed to process image"}, status=500)
     except Exception:
         logger.exception("[ExtractAPI] Exception during extraction")
         return JsonResponse({"error": "Failed to process image"}, status=500)

--- a/lib/llm/llm_call.py
+++ b/lib/llm/llm_call.py
@@ -22,6 +22,7 @@ class LLMCall(BaseModel):
     max_tokens: int | None = None
     retry_timeout: float | None = None
     retry_limit: int | None = None
+    max_wait_time: float | None = None
 
     model_config = {"arbitrary_types_allowed": True}
 

--- a/lib/llm/llm_handler.py
+++ b/lib/llm/llm_handler.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import logging
+import random
+import time
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any
 
@@ -96,17 +98,6 @@ class LangChainHandler(LLMHandler):
                 client_params["max_tokens"] = self.llm_call.max_tokens
             self.langchain_client = ChatBedrock(**client_params)
 
-        self._configure_langchain_client()
-
-    def _maybe_configure_retry(self) -> None:
-        if self.llm_call.should_retry():
-            self.langchain_client = self.langchain_client.with_retry(stop_after_attempt=self.llm_call.retry_limit + 1, wait_exponential_jitter=True)
-
-    def _configure_langchain_client(self) -> None:
-        """Configure the LangChain client with structured output and retry settings."""
-        # Apply retry configuration if needed
-        self._maybe_configure_retry()
-
     def add_message(self, role: str, content: list[dict[str, Any]]) -> None:
         """Add a message to the handler's message chain.
 
@@ -154,23 +145,86 @@ class LangChainHandler(LLMHandler):
         """The runnable chain that calls the LLM."""
         return self.llm_chain | StrOutputParser()
 
-    def query(self, **kwargs: str) -> str:
-        """Process a query using the configured LLM.
+    def _retry_backoff(self, attempt: int) -> None:
+        """Sleep with exponential backoff + jitter, optionally capped at max_wait_time.
+
+        Args:
+            attempt: The zero-based attempt number that just failed.
+        """
+        base = 2 ** attempt
+        if self.llm_call.max_wait_time is not None:
+            base = min(base, self.llm_call.max_wait_time)
+        sleep_time = base * (0.5 + random.random() * 0.5)  # noqa: S311
+        logger.info("[LLMHandler] Backing off %.2fs before attempt %d", sleep_time, attempt + 2)
+        time.sleep(sleep_time)
+
+    def _try_invoke(self, kwargs: dict[str, Any], attempt: int, retry_limit: int) -> str | BaseModel | None:
+        """Attempt a single invocation of the chain.
+
+        On transport/throttling errors, returns None to signal the caller
+        should retry (unless this is the final attempt, in which case
+        the exception is re-raised).
+
+        Args:
+            kwargs: Keyword arguments for the chain invocation.
+            attempt: The zero-based current attempt number.
+            retry_limit: Maximum number of retries (0 means no retries).
+
+        Returns:
+            The chain result on success, or None to signal a retry.
+
+        Raises:
+            Exception: On the final attempt for transport errors.
+        """
+        try:
+            return self.chain.invoke(kwargs)
+        except Exception as exc:
+            if attempt < retry_limit:
+                logger.warning(
+                    "[LLMHandler] Transport retry %d/%d — %s",
+                    attempt + 1, retry_limit, str(exc)[:200],
+                )
+                return None
+            raise
+
+    def query(self, **kwargs: str) -> str | BaseModel:
+        """Process a query using the configured LLM, with retry on failure.
+
+        Transport errors (network, throttling) are retried with the same
+        prompt. Subclasses may override ``_try_invoke`` to add additional
+        retry strategies (e.g. reask on validation errors).
 
         Args:
             **kwargs: Keyword arguments to be passed to the LLM prompt template.
 
         Returns:
-            str: The response from the LLM as a string.
+            str | BaseModel: The response from the LLM.
+
+        Raises:
+            TimeoutError: If retry_timeout is exceeded.
         """
-        # Ensure additional_messages is always present for the MessagesPlaceholder
         kwargs["additional_messages"] = kwargs.get("additional_messages", [])
         if self._additional_messages:
-            # Append handler's messages to any passed in via kwargs
             kwargs["additional_messages"] = self._additional_messages + kwargs["additional_messages"]
 
-        # Use the chain with the modified template that includes additional messages
-        return self.chain.invoke(kwargs)
+        retry_limit = self.llm_call.retry_limit or 0
+        timeout = self.llm_call.retry_timeout
+        start = time.monotonic()
+
+        for attempt in range(1 + retry_limit):
+            if timeout is not None and attempt > 0 and (time.monotonic() - start) >= timeout:
+                msg = f"LLM retry process exceeded {timeout}s timeout"
+                raise TimeoutError(msg)
+
+            result = self._try_invoke(kwargs, attempt, retry_limit)
+            if result is not None:
+                return result
+
+            if attempt < retry_limit:
+                self._retry_backoff(attempt)
+
+        msg = "LLM invocation returned None after all retry attempts"
+        raise RuntimeError(msg)
 
     def _build_image_content(self, image_data: str, mime_type: str) -> dict[str, Any]:
         """Build a provider-appropriate image content block.
@@ -217,16 +271,11 @@ class StructuredLangChainHandler(LangChainHandler):
         self.output_schema = output_schema
         super().__init__(llm_call=llm_call, region=region)
 
-    def _configure_langchain_client(self) -> None:
-        # Do NOT call super() — the parent applies .with_retry() which wraps the
-        # client in RunnableRetry and hides .with_structured_output().
-        # Transport-level retry is handled in query() alongside reask logic.
         logger.info("[LLMHandler] Configuring structured output for schema: %s", self.output_schema.__name__)
         try:
             self.langchain_client = self.langchain_client.with_structured_output(self.output_schema)
             logger.info("[LLMHandler] Structured output configured successfully")
         except (AttributeError, NotImplementedError) as e:
-            # Fall back to tool binding if structured_output isn't supported
             logger.warning("[LLMHandler] Falling back to bind_tools: %s", str(e))
             self.langchain_client = self.langchain_client.bind_tools([self.output_schema])
 
@@ -306,39 +355,6 @@ class StructuredLangChainHandler(LangChainHandler):
 
         msg = "Structured output returned None after all retry attempts"
         raise OutputParserException(msg)
-
-    def query(self, **kwargs: str) -> BaseModel:
-        """Process a query using the configured LLM, with retry on failure.
-
-        On each failed attempt the method checks the exception type:
-        - Reask exceptions (validation/parsing) → sends the error back to the
-          model so it can self-correct.
-        - All other exceptions (transport/throttling) → retries with the same
-          prompt unchanged.
-
-        Args:
-            **kwargs: Keyword arguments to be passed to the LLM prompt template.
-
-        Returns:
-            BaseModel: The response from the LLM as a structured Pydantic object.
-
-        Raises:
-            OutputParserException: If the model returns None after all attempts.
-            ValidationError: If the model produces invalid output after all attempts.
-        """
-        kwargs["additional_messages"] = kwargs.get("additional_messages", [])
-        if self._additional_messages:
-            kwargs["additional_messages"] = self._additional_messages + kwargs["additional_messages"]
-
-        retry_limit = self.llm_call.retry_limit if self.llm_call.should_retry() else 0
-
-        for attempt in range(1 + retry_limit):
-            result = self._try_invoke(kwargs, attempt, retry_limit)
-            if result is not None:
-                return result
-
-        msg = "Structured output returned None after all reask attempts"
-        raise OutputParserException(msg)  # unreachable
 
     def query_with_image(self, image_data: str, mime_type: str = "image/jpeg", **kwargs: str) -> BaseModel:
         """Process a query with an image using the configured LLM.

--- a/lib/llm/llm_handler.py
+++ b/lib/llm/llm_handler.py
@@ -11,15 +11,23 @@ from langchain.prompts import (
     SystemMessagePromptTemplate,
 )
 from langchain_aws.chat_models.bedrock import ChatBedrock
-from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_core.exceptions import OutputParserException
+from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_core.output_parsers import StrOutputParser
-from pydantic import ValidationError
 from langchain_google_genai import ChatGoogleGenerativeAI
+from pydantic import ValidationError
 
 from lib.llm.gemini_model_id import GeminiModelID
 
 logger = logging.getLogger(__name__)
+
+# Exceptions that warrant a *reask* — sending the error back to the model so it
+# can correct its output.  Everything else (throttling, network, etc.) gets a
+# naive retry with the same prompt.
+REASK_EXCEPTIONS: tuple[type[Exception], ...] = (
+    ValidationError,
+    OutputParserException,
+)
 
 if TYPE_CHECKING:
     from langchain.schema.runnable import Runnable
@@ -210,10 +218,9 @@ class StructuredLangChainHandler(LangChainHandler):
         super().__init__(llm_call=llm_call, region=region)
 
     def _configure_langchain_client(self) -> None:
-        # Apply retry BEFORE structured output so it only covers transport errors,
-        # not Pydantic validation failures from the output parser.
-        super()._configure_langchain_client()
-
+        # Do NOT call super() — the parent applies .with_retry() which wraps the
+        # client in RunnableRetry and hides .with_structured_output().
+        # Transport-level retry is handled in query() alongside reask logic.
         logger.info("[LLMHandler] Configuring structured output for schema: %s", self.output_schema.__name__)
         try:
             self.langchain_client = self.langchain_client.with_structured_output(self.output_schema)
@@ -245,8 +252,14 @@ class StructuredLangChainHandler(LangChainHandler):
             f"Please fix the following issues and try again:\n{exc!s}"
         ))
 
-    def _try_invoke(self, kwargs: dict[str, Any], attempt: int, reask_limit: int) -> BaseModel | None:
+    def _try_invoke(self, kwargs: dict[str, Any], attempt: int, retry_limit: int) -> BaseModel | None:
         """Attempt a single structured invocation.
+
+        Handles two retry strategies:
+        - *Reask*: For validation/parsing errors (REASK_EXCEPTIONS), sends the
+          error back to the model so it can correct its output.
+        - *Naive retry*: For transport/throttling errors (everything else),
+          retries with the same prompt unchanged.
 
         Returns:
             BaseModel on success, None to signal the caller should retry.
@@ -254,43 +267,54 @@ class StructuredLangChainHandler(LangChainHandler):
         Raises:
             OutputParserException: On the final attempt when the model returns None.
             ValidationError: On the final attempt when validation fails.
+            Exception: On the final attempt for transport errors.
         """
         try:
             result = self.chain.invoke(kwargs)
-        except (ValidationError, OutputParserException) as exc:
-            if attempt < reask_limit:
+        except REASK_EXCEPTIONS as exc:
+            if attempt < retry_limit:
                 logger.warning(
                     "[LLMHandler] Reask %d/%d — validation error: %s",
-                    attempt + 1, reask_limit, str(exc)[:200],
+                    attempt + 1, retry_limit, str(exc)[:200],
                 )
                 kwargs["additional_messages"] = kwargs["additional_messages"] + [
                     self._build_reask_message_for_error(exc)
                 ]
                 return None
             raise
+        except Exception as exc:
+            if attempt < retry_limit:
+                logger.warning(
+                    "[LLMHandler] Naive retry %d/%d — transport error: %s",
+                    attempt + 1, retry_limit, str(exc)[:200],
+                )
+                return None
+            raise
 
         if result is not None:
             return result
 
-        if attempt < reask_limit:
+        if attempt < retry_limit:
             logger.warning(
                 "[LLMHandler] Reask %d/%d — model returned None (no tool call)",
-                attempt + 1, reask_limit,
+                attempt + 1, retry_limit,
             )
             kwargs["additional_messages"] = kwargs["additional_messages"] + [
                 self._build_reask_message_for_none()
             ]
             return None
 
-        msg = "Structured output returned None after all reask attempts"
+        msg = "Structured output returned None after all retry attempts"
         raise OutputParserException(msg)
 
     def query(self, **kwargs: str) -> BaseModel:
-        """Process a query using the configured LLM, with optional reask on failure.
+        """Process a query using the configured LLM, with retry on failure.
 
-        When `retry_limit` is set on the LLM call, the method will retry up to
-        that many times if the model returns None (no tool call) or raises a
-        validation error, sending the specific error back to the model each time.
+        On each failed attempt the method checks the exception type:
+        - Reask exceptions (validation/parsing) → sends the error back to the
+          model so it can self-correct.
+        - All other exceptions (transport/throttling) → retries with the same
+          prompt unchanged.
 
         Args:
             **kwargs: Keyword arguments to be passed to the LLM prompt template.
@@ -306,10 +330,10 @@ class StructuredLangChainHandler(LangChainHandler):
         if self._additional_messages:
             kwargs["additional_messages"] = self._additional_messages + kwargs["additional_messages"]
 
-        reask_limit = self.llm_call.retry_limit or 0
+        retry_limit = self.llm_call.retry_limit or 0
 
-        for attempt in range(1 + reask_limit):
-            result = self._try_invoke(kwargs, attempt, reask_limit)
+        for attempt in range(1 + retry_limit):
+            result = self._try_invoke(kwargs, attempt, retry_limit)
             if result is not None:
                 return result
 

--- a/lib/llm/llm_handler.py
+++ b/lib/llm/llm_handler.py
@@ -100,7 +100,7 @@ class LangChainHandler(LLMHandler):
 
     def _maybe_configure_retry(self) -> None:
         if self.llm_call.should_retry():
-            self.langchain_client = self.langchain_client.with_retry(stop_after_attempt=self.llm_call.retry_limit, wait_exponential_jitter=True)
+            self.langchain_client = self.langchain_client.with_retry(stop_after_attempt=self.llm_call.retry_limit + 1, wait_exponential_jitter=True)
 
     def _configure_langchain_client(self) -> None:
         """Configure the LangChain client with structured output and retry settings."""
@@ -330,7 +330,7 @@ class StructuredLangChainHandler(LangChainHandler):
         if self._additional_messages:
             kwargs["additional_messages"] = self._additional_messages + kwargs["additional_messages"]
 
-        retry_limit = self.llm_call.retry_limit or 0
+        retry_limit = self.llm_call.retry_limit if self.llm_call.should_retry() else 0
 
         for attempt in range(1 + retry_limit):
             result = self._try_invoke(kwargs, attempt, retry_limit)

--- a/lib/llm/llm_handler.py
+++ b/lib/llm/llm_handler.py
@@ -12,7 +12,9 @@ from langchain.prompts import (
 )
 from langchain_aws.chat_models.bedrock import ChatBedrock
 from langchain_core.messages import HumanMessage, SystemMessage
+from langchain_core.exceptions import OutputParserException
 from langchain_core.output_parsers import StrOutputParser
+from pydantic import ValidationError
 from langchain_google_genai import ChatGoogleGenerativeAI
 
 from lib.llm.gemini_model_id import GeminiModelID
@@ -208,7 +210,10 @@ class StructuredLangChainHandler(LangChainHandler):
         super().__init__(llm_call=llm_call, region=region)
 
     def _configure_langchain_client(self) -> None:
-        # Always use structured_output for all models (disable Claude 4 XML fallback)
+        # Apply retry BEFORE structured output so it only covers transport errors,
+        # not Pydantic validation failures from the output parser.
+        super()._configure_langchain_client()
+
         logger.info("[LLMHandler] Configuring structured output for schema: %s", self.output_schema.__name__)
         try:
             self.langchain_client = self.langchain_client.with_structured_output(self.output_schema)
@@ -218,30 +223,98 @@ class StructuredLangChainHandler(LangChainHandler):
             logger.warning("[LLMHandler] Falling back to bind_tools: %s", str(e))
             self.langchain_client = self.langchain_client.bind_tools([self.output_schema])
 
-        super()._configure_langchain_client()
-
     @property
     def chain(self) -> Runnable[LanguageModelInput, BaseModel]:
         """The runnable chain that calls the LLM and parses the output to a structured format."""
         return self.llm_chain
 
+    @staticmethod
+    def _build_reask_message_for_none() -> HumanMessage:
+        """Build a reask message when the model fails to produce a tool call."""
+        return HumanMessage(content=(
+            "Your previous response did not use the required tool/function call. "
+            "You must respond by calling the provided tool with the appropriate arguments. "
+            "Please try again."
+        ))
+
+    @staticmethod
+    def _build_reask_message_for_error(exc: Exception) -> HumanMessage:
+        """Build a reask message with specific validation errors."""
+        return HumanMessage(content=(
+            "Your previous tool call had validation errors. "
+            f"Please fix the following issues and try again:\n{exc!s}"
+        ))
+
+    def _try_invoke(self, kwargs: dict[str, Any], attempt: int, reask_limit: int) -> BaseModel | None:
+        """Attempt a single structured invocation.
+
+        Returns:
+            BaseModel on success, None to signal the caller should retry.
+
+        Raises:
+            OutputParserException: On the final attempt when the model returns None.
+            ValidationError: On the final attempt when validation fails.
+        """
+        try:
+            result = self.chain.invoke(kwargs)
+        except (ValidationError, OutputParserException) as exc:
+            if attempt < reask_limit:
+                logger.warning(
+                    "[LLMHandler] Reask %d/%d — validation error: %s",
+                    attempt + 1, reask_limit, str(exc)[:200],
+                )
+                kwargs["additional_messages"] = kwargs["additional_messages"] + [
+                    self._build_reask_message_for_error(exc)
+                ]
+                return None
+            raise
+
+        if result is not None:
+            return result
+
+        if attempt < reask_limit:
+            logger.warning(
+                "[LLMHandler] Reask %d/%d — model returned None (no tool call)",
+                attempt + 1, reask_limit,
+            )
+            kwargs["additional_messages"] = kwargs["additional_messages"] + [
+                self._build_reask_message_for_none()
+            ]
+            return None
+
+        msg = "Structured output returned None after all reask attempts"
+        raise OutputParserException(msg)
+
     def query(self, **kwargs: str) -> BaseModel:
-        """Process a query using the configured LLM.
+        """Process a query using the configured LLM, with optional reask on failure.
+
+        When `retry_limit` is set on the LLM call, the method will retry up to
+        that many times if the model returns None (no tool call) or raises a
+        validation error, sending the specific error back to the model each time.
 
         Args:
             **kwargs: Keyword arguments to be passed to the LLM prompt template.
 
         Returns:
             BaseModel: The response from the LLM as a structured Pydantic object.
+
+        Raises:
+            OutputParserException: If the model returns None after all attempts.
+            ValidationError: If the model produces invalid output after all attempts.
         """
-        # Add additional messages to kwargs if they exist
         kwargs["additional_messages"] = kwargs.get("additional_messages", [])
         if self._additional_messages:
-            # Append new additional messages to existing ones
             kwargs["additional_messages"] = self._additional_messages + kwargs["additional_messages"]
 
-        # Use the chain with the modified template that includes additional messages
-        return self.chain.invoke(kwargs)
+        reask_limit = self.llm_call.retry_limit or 0
+
+        for attempt in range(1 + reask_limit):
+            result = self._try_invoke(kwargs, attempt, reask_limit)
+            if result is not None:
+                return result
+
+        msg = "Structured output returned None after all reask attempts"
+        raise OutputParserException(msg)  # unreachable
 
     def query_with_image(self, image_data: str, mime_type: str = "image/jpeg", **kwargs: str) -> BaseModel:
         """Process a query with an image using the configured LLM.

--- a/lib/llm/llm_handler.py
+++ b/lib/llm/llm_handler.py
@@ -225,7 +225,7 @@ class StructuredLangChainHandler(LangChainHandler):
         try:
             self.langchain_client = self.langchain_client.with_structured_output(self.output_schema)
             logger.info("[LLMHandler] Structured output configured successfully")
-        except (AttributeError, NotImplementedError, Exception) as e:
+        except (AttributeError, NotImplementedError) as e:
             # Fall back to tool binding if structured_output isn't supported
             logger.warning("[LLMHandler] Falling back to bind_tools: %s", str(e))
             self.langchain_client = self.langchain_client.bind_tools([self.output_schema])

--- a/lib/llm/llm_handler.py
+++ b/lib/llm/llm_handler.py
@@ -50,7 +50,7 @@ class LLMHandler(ABC):
     llm_call: LLMCall
 
     @abstractmethod
-    def query(self, **kwargs: str) -> str | BaseModel:
+    def query(self, **kwargs: Any) -> str | BaseModel:
         """Process a query using the configured LLM.
 
         Args:
@@ -187,7 +187,7 @@ class LangChainHandler(LLMHandler):
                 return None
             raise
 
-    def query(self, **kwargs: str) -> str | BaseModel:
+    def query(self, **kwargs: Any) -> str | BaseModel:
         """Process a query using the configured LLM, with retry on failure.
 
         Transport errors (network, throttling) are retried with the same
@@ -240,7 +240,7 @@ class LangChainHandler(LLMHandler):
             return {"type": "image_url", "image_url": {"url": f"data:{mime_type};base64,{image_data}"}}
         return {"type": "image", "source_type": "base64", "data": image_data, "mime_type": mime_type}
 
-    def query_with_image(self, image_data: str, mime_type: str = "image/jpeg", **kwargs: str) -> str:
+    def query_with_image(self, image_data: str, mime_type: str = "image/jpeg", **kwargs: Any) -> str:
         """Process a query with an image using the configured LLM.
 
         Args:
@@ -356,7 +356,7 @@ class StructuredLangChainHandler(LangChainHandler):
         msg = "Structured output returned None after all retry attempts"
         raise OutputParserException(msg)
 
-    def query_with_image(self, image_data: str, mime_type: str = "image/jpeg", **kwargs: str) -> BaseModel:
+    def query_with_image(self, image_data: str, mime_type: str = "image/jpeg", **kwargs: Any) -> BaseModel:
         """Process a query with an image using the configured LLM.
 
         Args:

--- a/lib/llm/tests/test_llm_handler.py
+++ b/lib/llm/tests/test_llm_handler.py
@@ -7,7 +7,8 @@ from langchain.prompts import (
     SystemMessagePromptTemplate,
 )
 from langchain.schema.messages import HumanMessage, SystemMessage
-from pydantic import BaseModel
+from langchain_core.exceptions import OutputParserException
+from pydantic import BaseModel, ValidationError
 
 from aws_utils.model_id import ClaudeModelID
 from aws_utils.region import AWSRegion
@@ -525,6 +526,162 @@ class TestStructuredLangChainHandler:
 
 
 # The abstract LLMHandler base class is indirectly tested through the concrete implementations above.
+
+
+class TestStructuredReask:
+    """Test cases for the reask loop in StructuredLangChainHandler."""
+
+    @pytest.fixture
+    def output_schema(self) -> type[DummyOutputSchema]:
+        return DummyOutputSchema
+
+    @pytest.fixture
+    def llm_call_no_retry(self, system_prompt: str, model_id: ClaudeModelID) -> LLMCall:
+        """LLMCall without retry (default behavior)."""
+        return LLMCall(
+            system_prompt_tmplt=system_prompt,
+            model_id=model_id,
+        )
+
+    @pytest.fixture
+    def llm_call_with_retry(self, system_prompt: str, model_id: ClaudeModelID) -> LLMCall:
+        """LLMCall with retry_limit=2."""
+        return LLMCall(
+            system_prompt_tmplt=system_prompt,
+            model_id=model_id,
+            retry_limit=2,
+        )
+
+    def test_query_none_without_retry_raises(
+        self,
+        llm_call_no_retry: LLMCall,
+        output_schema: type[DummyOutputSchema],
+        region: AWSRegion,
+        mock_bedrock_client: MagicMock,
+    ) -> None:
+        """When retry is disabled and invoke returns None, raises immediately."""
+        handler = StructuredLangChainHandler(llm_call_no_retry, output_schema, region)
+
+        with patch.object(StructuredLangChainHandler, "chain") as mock_chain:
+            mock_chain.invoke.return_value = None
+            with pytest.raises(OutputParserException, match="None"):
+                handler.query()
+
+        assert mock_chain.invoke.call_count == 1
+
+    def test_query_none_with_retry_succeeds(
+        self,
+        llm_call_with_retry: LLMCall,
+        output_schema: type[DummyOutputSchema],
+        region: AWSRegion,
+        mock_bedrock_client: MagicMock,
+    ) -> None:
+        """When invoke returns None then valid result, reask recovers."""
+        handler = StructuredLangChainHandler(llm_call_with_retry, output_schema, region)
+        valid_result = DummyOutputSchema(field1="ok", field2=1)
+
+        with patch.object(StructuredLangChainHandler, "chain") as mock_chain:
+            mock_chain.invoke.side_effect = [None, valid_result]
+            result = handler.query()
+
+        assert result == valid_result
+        assert mock_chain.invoke.call_count == 2
+        # Second call should have a reask message appended
+        second_call_kwargs = mock_chain.invoke.call_args_list[1][0][0]
+        reask_msgs = second_call_kwargs["additional_messages"]
+        assert len(reask_msgs) == 1
+        assert isinstance(reask_msgs[0], HumanMessage)
+        assert "tool" in reask_msgs[0].content.lower()
+
+    def test_query_validation_error_with_retry_succeeds(
+        self,
+        llm_call_with_retry: LLMCall,
+        output_schema: type[DummyOutputSchema],
+        region: AWSRegion,
+        mock_bedrock_client: MagicMock,
+    ) -> None:
+        """When invoke raises ValidationError then returns valid, reask recovers."""
+        handler = StructuredLangChainHandler(llm_call_with_retry, output_schema, region)
+        valid_result = DummyOutputSchema(field1="ok", field2=1)
+
+        # Create a real ValidationError by trying to validate bad data
+        try:
+            DummyOutputSchema(field1=123, field2="not_an_int")
+        except ValidationError as e:
+            validation_err = e
+
+        with patch.object(StructuredLangChainHandler, "chain") as mock_chain:
+            mock_chain.invoke.side_effect = [validation_err, valid_result]
+            result = handler.query()
+
+        assert result == valid_result
+        assert mock_chain.invoke.call_count == 2
+        second_call_kwargs = mock_chain.invoke.call_args_list[1][0][0]
+        reask_msgs = second_call_kwargs["additional_messages"]
+        assert len(reask_msgs) == 1
+        assert "validation error" in reask_msgs[0].content.lower()
+
+    def test_query_exhausts_reask_none(
+        self,
+        llm_call_with_retry: LLMCall,
+        output_schema: type[DummyOutputSchema],
+        region: AWSRegion,
+        mock_bedrock_client: MagicMock,
+    ) -> None:
+        """When all attempts return None, raises OutputParserException."""
+        handler = StructuredLangChainHandler(llm_call_with_retry, output_schema, region)
+
+        with patch.object(StructuredLangChainHandler, "chain") as mock_chain:
+            mock_chain.invoke.return_value = None
+            with pytest.raises(OutputParserException, match="None"):
+                handler.query()
+
+        # 1 initial + 2 reasks = 3 total
+        assert mock_chain.invoke.call_count == 3
+
+    def test_query_exhausts_reask_validation_error(
+        self,
+        llm_call_with_retry: LLMCall,
+        output_schema: type[DummyOutputSchema],
+        region: AWSRegion,
+        mock_bedrock_client: MagicMock,
+    ) -> None:
+        """When all attempts raise ValidationError, re-raises the last one."""
+        handler = StructuredLangChainHandler(llm_call_with_retry, output_schema, region)
+
+        try:
+            DummyOutputSchema(field1=123, field2="not_an_int")
+        except ValidationError as e:
+            validation_err = e
+
+        with patch.object(StructuredLangChainHandler, "chain") as mock_chain:
+            mock_chain.invoke.side_effect = validation_err
+            with pytest.raises(ValidationError):
+                handler.query()
+
+        assert mock_chain.invoke.call_count == 3
+
+    def test_reask_messages_accumulate(
+        self,
+        llm_call_with_retry: LLMCall,
+        output_schema: type[DummyOutputSchema],
+        region: AWSRegion,
+        mock_bedrock_client: MagicMock,
+    ) -> None:
+        """Each reask appends a new message, so they accumulate."""
+        handler = StructuredLangChainHandler(llm_call_with_retry, output_schema, region)
+        valid_result = DummyOutputSchema(field1="ok", field2=1)
+
+        with patch.object(StructuredLangChainHandler, "chain") as mock_chain:
+            mock_chain.invoke.side_effect = [None, None, valid_result]
+            result = handler.query()
+
+        assert result == valid_result
+        assert mock_chain.invoke.call_count == 3
+        # Third call should have 2 accumulated reask messages
+        third_call_kwargs = mock_chain.invoke.call_args_list[2][0][0]
+        reask_msgs = third_call_kwargs["additional_messages"]
+        assert len(reask_msgs) == 2
 
 
 class TestGeminiLangChainHandler:

--- a/lib/llm/tests/test_llm_handler.py
+++ b/lib/llm/tests/test_llm_handler.py
@@ -645,7 +645,7 @@ class TestStructuredReask:
         reask_msgs = second_call_kwargs["additional_messages"]
         assert len(reask_msgs) == 1
         assert isinstance(reask_msgs[0], HumanMessage)
-        assert "tool" in reask_msgs[0].content.lower()
+        assert "did not use the required tool" in reask_msgs[0].content
 
     def test_query_validation_error_with_retry_succeeds(
         self,
@@ -673,7 +673,8 @@ class TestStructuredReask:
         second_call_kwargs = mock_chain.invoke.call_args_list[1][0][0]
         reask_msgs = second_call_kwargs["additional_messages"]
         assert len(reask_msgs) == 1
-        assert "validation error" in reask_msgs[0].content.lower()
+        assert "validation errors" in reask_msgs[0].content.lower()
+        assert str(validation_err) in reask_msgs[0].content
 
     def test_query_exhausts_reask_none(
         self,
@@ -1081,7 +1082,8 @@ class TestOutputParserExceptionReask:
         reask_msgs = second_call_kwargs["additional_messages"]
         assert len(reask_msgs) == 1
         assert isinstance(reask_msgs[0], HumanMessage)
-        assert "validation error" in reask_msgs[0].content.lower()
+        assert "validation errors" in reask_msgs[0].content.lower()
+        assert "malformed tool call" in reask_msgs[0].content
 
     def test_output_parser_exception_exhausted_reraises(
         self,

--- a/lib/llm/tests/test_llm_handler.py
+++ b/lib/llm/tests/test_llm_handler.py
@@ -777,3 +777,261 @@ class TestGeminiStructuredHandler:
         assert image_content["type"] == "image_url"
         assert image_content["image_url"]["url"] == "data:image/jpeg;base64,test_b64"
         assert result == expected_output
+
+
+class TestTransportRetry:
+    """Test cases for transport (non-reask) error retry in StructuredLangChainHandler."""
+
+    @pytest.fixture
+    def output_schema(self) -> type[DummyOutputSchema]:
+        return DummyOutputSchema
+
+    @pytest.fixture
+    def llm_call_with_retry(self, system_prompt: str, model_id: ClaudeModelID) -> LLMCall:
+        return LLMCall(
+            system_prompt_tmplt=system_prompt,
+            model_id=model_id,
+            retry_limit=2,
+        )
+
+    @pytest.fixture
+    def llm_call_no_retry(self, system_prompt: str, model_id: ClaudeModelID) -> LLMCall:
+        return LLMCall(
+            system_prompt_tmplt=system_prompt,
+            model_id=model_id,
+        )
+
+    def test_transport_error_then_success_no_reask_message(
+        self,
+        llm_call_with_retry: LLMCall,
+        output_schema: type[DummyOutputSchema],
+        region: AWSRegion,
+        mock_bedrock_client: MagicMock,
+    ) -> None:
+        """Transport errors retry with the same prompt — no reask message appended."""
+        handler = StructuredLangChainHandler(llm_call_with_retry, output_schema, region)
+        valid_result = DummyOutputSchema(field1="ok", field2=1)
+
+        with patch.object(StructuredLangChainHandler, "chain") as mock_chain:
+            mock_chain.invoke.side_effect = [RuntimeError("throttled"), valid_result]
+            result = handler.query()
+
+        assert result == valid_result
+        assert mock_chain.invoke.call_count == 2
+        # Key assertion: additional_messages must be empty on retry (no reask feedback)
+        second_call_kwargs = mock_chain.invoke.call_args_list[1][0][0]
+        assert second_call_kwargs["additional_messages"] == []
+
+    def test_transport_error_exhausted_reraises(
+        self,
+        llm_call_with_retry: LLMCall,
+        output_schema: type[DummyOutputSchema],
+        region: AWSRegion,
+        mock_bedrock_client: MagicMock,
+    ) -> None:
+        """When all attempts fail with transport errors, re-raises the last one."""
+        handler = StructuredLangChainHandler(llm_call_with_retry, output_schema, region)
+
+        with patch.object(StructuredLangChainHandler, "chain") as mock_chain:
+            mock_chain.invoke.side_effect = RuntimeError("service unavailable")
+            with pytest.raises(RuntimeError, match="service unavailable"):
+                handler.query()
+
+        # 1 initial + 2 retries = 3 total
+        assert mock_chain.invoke.call_count == 3
+
+    def test_transport_error_without_retry_raises_immediately(
+        self,
+        llm_call_no_retry: LLMCall,
+        output_schema: type[DummyOutputSchema],
+        region: AWSRegion,
+        mock_bedrock_client: MagicMock,
+    ) -> None:
+        """Without retry configured, transport errors raise immediately."""
+        handler = StructuredLangChainHandler(llm_call_no_retry, output_schema, region)
+
+        with patch.object(StructuredLangChainHandler, "chain") as mock_chain:
+            mock_chain.invoke.side_effect = RuntimeError("network error")
+            with pytest.raises(RuntimeError, match="network error"):
+                handler.query()
+
+        assert mock_chain.invoke.call_count == 1
+
+
+class TestConfigureEdgeCases:
+    """Test cases for initialization edge cases and configuration branches."""
+
+    @pytest.fixture
+    def output_schema(self) -> type[DummyOutputSchema]:
+        return DummyOutputSchema
+
+    def test_structured_handler_falls_back_to_bind_tools(
+        self,
+        system_prompt: str,
+        model_id: ClaudeModelID,
+        region: AWSRegion,
+        mock_bedrock_client: MagicMock,
+    ) -> None:
+        """When with_structured_output fails, falls back to bind_tools."""
+        mock_instance = mock_bedrock_client.return_value
+        mock_instance.with_structured_output.side_effect = NotImplementedError("not supported")
+
+        llm_call = LLMCall(system_prompt_tmplt=system_prompt, model_id=model_id)
+        handler = StructuredLangChainHandler(llm_call, DummyOutputSchema, region)
+
+        mock_instance.with_structured_output.assert_called_once_with(DummyOutputSchema)
+        mock_instance.bind_tools.assert_called_once_with([DummyOutputSchema])
+        assert handler.output_schema == DummyOutputSchema
+
+    def test_max_tokens_passed_to_bedrock_client(
+        self,
+        system_prompt: str,
+        human_prompt: str,
+        model_id: ClaudeModelID,
+        region: AWSRegion,
+        mock_bedrock_client: MagicMock,
+    ) -> None:
+        """When max_tokens is set, it is included in client parameters."""
+        llm_call = LLMCall(
+            system_prompt_tmplt=system_prompt,
+            human_prompt_tmplt=human_prompt,
+            model_id=model_id,
+            max_tokens=1024,
+        )
+        LangChainHandler(llm_call, region)
+
+        mock_bedrock_client.assert_called_once_with(
+            model_id=model_id.value,
+            temperature=llm_call.temp,
+            region=region.value,
+            max_tokens=1024,
+        )
+
+    def test_max_tokens_passed_to_gemini_client(
+        self,
+        system_prompt: str,
+        human_prompt: str,
+        mock_gemini_client: MagicMock,
+    ) -> None:
+        """When max_tokens is set on a Gemini call, it is included in client parameters."""
+        gemini_model = GeminiModelID.GEMINI_3_FLASH_PREVIEW
+        llm_call = LLMCall(
+            system_prompt_tmplt=system_prompt,
+            human_prompt_tmplt=human_prompt,
+            model_id=gemini_model,
+            max_tokens=2048,
+        )
+        LangChainHandler(llm_call)
+
+        mock_gemini_client.assert_called_once_with(
+            model=gemini_model.value,
+            temperature=llm_call.temp,
+            max_tokens=2048,
+        )
+
+    def test_prompt_template_with_no_human_prompt(
+        self,
+        system_prompt: str,
+        model_id: ClaudeModelID,
+        region: AWSRegion,
+        mock_bedrock_client: MagicMock,
+    ) -> None:
+        """When human_prompt_tmplt is None, template has only system + placeholder."""
+        llm_call = LLMCall(system_prompt_tmplt=system_prompt, model_id=model_id)
+        handler = LangChainHandler(llm_call, region)
+
+        template = handler.lc_prompt_tmplt
+        assert len(template.messages) == 2
+        assert isinstance(template.messages[0], SystemMessagePromptTemplate)
+        assert isinstance(template.messages[1], MessagesPlaceholder)
+
+
+class TestStructuredQueryWithImageException:
+    """Test the exception logging path in StructuredLangChainHandler.query_with_image."""
+
+    @pytest.fixture
+    def output_schema(self) -> type[DummyOutputSchema]:
+        return DummyOutputSchema
+
+    def test_query_with_image_logs_and_reraises_exception(
+        self,
+        system_prompt: str,
+        model_id: ClaudeModelID,
+        output_schema: type[DummyOutputSchema],
+        region: AWSRegion,
+        mock_bedrock_client: MagicMock,
+    ) -> None:
+        """When query fails inside query_with_image, the exception is logged and re-raised."""
+        llm_call = LLMCall(system_prompt_tmplt=system_prompt, model_id=model_id)
+        handler = StructuredLangChainHandler(llm_call, output_schema, region)
+
+        with (
+            patch.object(StructuredLangChainHandler, "chain") as mock_chain,
+            patch("lib.llm.llm_handler.logger") as mock_logger,
+        ):
+            mock_chain.invoke.side_effect = OutputParserException("bad output")
+            with pytest.raises(OutputParserException, match="bad output"):
+                handler.query_with_image(image_data="b64data")
+
+        mock_logger.exception.assert_called_once()
+        assert "FAILED" in mock_logger.exception.call_args[0][0]
+
+
+class TestOutputParserExceptionReask:
+    """Test that OutputParserException triggers reask (not naive retry)."""
+
+    @pytest.fixture
+    def output_schema(self) -> type[DummyOutputSchema]:
+        return DummyOutputSchema
+
+    @pytest.fixture
+    def llm_call_with_retry(self, system_prompt: str, model_id: ClaudeModelID) -> LLMCall:
+        return LLMCall(
+            system_prompt_tmplt=system_prompt,
+            model_id=model_id,
+            retry_limit=2,
+        )
+
+    def test_output_parser_exception_triggers_reask(
+        self,
+        llm_call_with_retry: LLMCall,
+        output_schema: type[DummyOutputSchema],
+        region: AWSRegion,
+        mock_bedrock_client: MagicMock,
+    ) -> None:
+        """OutputParserException is a reask exception — error feedback is appended."""
+        handler = StructuredLangChainHandler(llm_call_with_retry, output_schema, region)
+        valid_result = DummyOutputSchema(field1="recovered", field2=1)
+
+        with patch.object(StructuredLangChainHandler, "chain") as mock_chain:
+            mock_chain.invoke.side_effect = [
+                OutputParserException("malformed tool call"),
+                valid_result,
+            ]
+            result = handler.query()
+
+        assert result == valid_result
+        assert mock_chain.invoke.call_count == 2
+        # Reask message should contain the error, not be empty like a naive retry
+        second_call_kwargs = mock_chain.invoke.call_args_list[1][0][0]
+        reask_msgs = second_call_kwargs["additional_messages"]
+        assert len(reask_msgs) == 1
+        assert isinstance(reask_msgs[0], HumanMessage)
+        assert "validation error" in reask_msgs[0].content.lower()
+
+    def test_output_parser_exception_exhausted_reraises(
+        self,
+        llm_call_with_retry: LLMCall,
+        output_schema: type[DummyOutputSchema],
+        region: AWSRegion,
+        mock_bedrock_client: MagicMock,
+    ) -> None:
+        """When all attempts raise OutputParserException, re-raises the last one."""
+        handler = StructuredLangChainHandler(llm_call_with_retry, output_schema, region)
+
+        with patch.object(StructuredLangChainHandler, "chain") as mock_chain:
+            mock_chain.invoke.side_effect = OutputParserException("persistent parse error")
+            with pytest.raises(OutputParserException, match="persistent parse error"):
+                handler.query()
+
+        assert mock_chain.invoke.call_count == 3

--- a/lib/llm/tests/test_llm_handler.py
+++ b/lib/llm/tests/test_llm_handler.py
@@ -78,20 +78,6 @@ class TestLangChainHandler:
             region=region.value,
         )
 
-        mock_instance = mock_bedrock_client.return_value
-        assert not mock_instance.with_retry.called
-
-    def test_init_with_retry(self, llm_call_with_retry: LLMCall, region: AWSRegion, mock_bedrock_client: MagicMock) -> None:
-        """Test that LangChainHandler initializes correctly with retry configuration."""
-        _ = LangChainHandler(llm_call_with_retry, region)
-
-        mock_bedrock_client.assert_called_once()
-        mock_instance = mock_bedrock_client.return_value
-        mock_instance.with_retry.assert_called_once_with(
-            stop_after_attempt=llm_call_with_retry.retry_limit,
-            wait_exponential_jitter=True,
-        )
-
     def test_lc_prompt_tmplt_property(self, llm_call: LLMCall, region: AWSRegion, mock_bedrock_client: MagicMock) -> None:
         """Test that the lc_prompt_tmplt property returns a correctly configured ChatPromptTemplate."""
         handler = LangChainHandler(llm_call, region)
@@ -291,6 +277,69 @@ class TestLangChainHandler:
         image_content = image_message.content[0]
         assert image_content["mime_type"] == "image/jpeg"
         assert result == "Default MIME type response"
+
+    @patch("lib.llm.llm_handler.time.sleep")
+    def test_query_transport_retry_success(
+        self, mock_sleep: MagicMock, region: AWSRegion, mock_bedrock_client: MagicMock, system_prompt: str, model_id: ClaudeModelID
+    ) -> None:
+        """Transport errors are retried and can recover."""
+        llm_call = LLMCall(system_prompt_tmplt=system_prompt, model_id=model_id, retry_limit=2)
+        handler = LangChainHandler(llm_call, region)
+
+        with patch.object(LangChainHandler, "chain") as mock_chain:
+            mock_chain.invoke.side_effect = [RuntimeError("throttled"), "recovered"]
+            result = handler.query(question="test")
+
+        assert result == "recovered"
+        assert mock_chain.invoke.call_count == 2
+        mock_sleep.assert_called_once()
+
+    @patch("lib.llm.llm_handler.time.sleep")
+    def test_query_transport_retry_exhausted(
+        self, mock_sleep: MagicMock, region: AWSRegion, mock_bedrock_client: MagicMock, system_prompt: str, model_id: ClaudeModelID
+    ) -> None:
+        """When all attempts fail with transport errors, re-raises the last one."""
+        llm_call = LLMCall(system_prompt_tmplt=system_prompt, model_id=model_id, retry_limit=2)
+        handler = LangChainHandler(llm_call, region)
+
+        with patch.object(LangChainHandler, "chain") as mock_chain:
+            mock_chain.invoke.side_effect = RuntimeError("service unavailable")
+            with pytest.raises(RuntimeError, match="service unavailable"):
+                handler.query(question="test")
+
+        assert mock_chain.invoke.call_count == 3
+
+    def test_query_no_retry_raises_immediately(
+        self, llm_call: LLMCall, region: AWSRegion, mock_bedrock_client: MagicMock
+    ) -> None:
+        """Without retry configured, transport errors raise immediately."""
+        handler = LangChainHandler(llm_call, region)
+
+        with patch.object(LangChainHandler, "chain") as mock_chain:
+            mock_chain.invoke.side_effect = RuntimeError("network error")
+            with pytest.raises(RuntimeError, match="network error"):
+                handler.query(question="test")
+
+        assert mock_chain.invoke.call_count == 1
+
+    @patch("lib.llm.llm_handler.time.sleep")
+    @patch("lib.llm.llm_handler.time.monotonic")
+    def test_query_timeout(
+        self, mock_monotonic: MagicMock, mock_sleep: MagicMock, region: AWSRegion, mock_bedrock_client: MagicMock, system_prompt: str, model_id: ClaudeModelID
+    ) -> None:
+        """TimeoutError is raised when retry_timeout is exceeded."""
+        llm_call = LLMCall(system_prompt_tmplt=system_prompt, model_id=model_id, retry_limit=5, retry_timeout=10.0)
+        handler = LangChainHandler(llm_call, region)
+
+        # First call: start=0.0, second: elapsed=11.0 > 10.0 timeout
+        mock_monotonic.side_effect = [0.0, 11.0]
+
+        with patch.object(LangChainHandler, "chain") as mock_chain:
+            mock_chain.invoke.side_effect = RuntimeError("throttled")
+            with pytest.raises(TimeoutError, match="10.0s timeout"):
+                handler.query(question="test")
+
+        assert mock_chain.invoke.call_count == 1
 
 
 class TestStructuredLangChainHandler:
@@ -530,6 +579,11 @@ class TestStructuredLangChainHandler:
 
 class TestStructuredReask:
     """Test cases for the reask loop in StructuredLangChainHandler."""
+
+    @pytest.fixture(autouse=True)
+    def _no_sleep(self) -> None:
+        with patch("lib.llm.llm_handler.time.sleep"):
+            yield
 
     @pytest.fixture
     def output_schema(self) -> type[DummyOutputSchema]:
@@ -782,6 +836,11 @@ class TestGeminiStructuredHandler:
 class TestTransportRetry:
     """Test cases for transport (non-reask) error retry in StructuredLangChainHandler."""
 
+    @pytest.fixture(autouse=True)
+    def _no_sleep(self) -> None:
+        with patch("lib.llm.llm_handler.time.sleep"):
+            yield
+
     @pytest.fixture
     def output_schema(self) -> type[DummyOutputSchema]:
         return DummyOutputSchema
@@ -979,6 +1038,11 @@ class TestStructuredQueryWithImageException:
 
 class TestOutputParserExceptionReask:
     """Test that OutputParserException triggers reask (not naive retry)."""
+
+    @pytest.fixture(autouse=True)
+    def _no_sleep(self) -> None:
+        with patch("lib.llm.llm_handler.time.sleep"):
+            yield
 
     @pytest.fixture
     def output_schema(self) -> type[DummyOutputSchema]:

--- a/llm_calls/item_generation/item_image_generation.json
+++ b/llm_calls/item_generation/item_image_generation.json
@@ -2,7 +2,7 @@
 {
     "system_prompt_tmplt": "You are a faithful assistant that helps with inventory management. You will receive images of Items that are being placed into storage, and must generate helpful names and descriptions of the main Item in the image. These names and descriptions will be used in future searches, where the user will ask a search engine to locate the Item. Think about which properties a user is likely to mention in their search query, and include these properties in the Item name and description. These should include the Item model, make, colour, type, purpose, etc.  If you cannot determine a suitable name or description or cannot interpret the image, please return 'Unknown' for both. Important: The item name must be at most 30 characters. The description must be at most 200 characters.",
     "human_prompt_tmplt": null,
-    "model_id": "us.anthropic.claude-sonnet-4-6",
+    "model_id": "gemini-3.1-flash-lite-preview",
     "max_tokens": 100,
     "temp": 0.3,
     "retry_timeout": 1,

--- a/llm_calls/item_generation/item_image_generation.json
+++ b/llm_calls/item_generation/item_image_generation.json
@@ -1,10 +1,10 @@
 
 {
-    "system_prompt_tmplt": "You are a faithful assistant that helps with inventory management. You will receive images of Items that are being placed into storage, and must generate helpful names and descriptions of the main Item in the image. These names and descriptions will be used in future searches, where the user will ask a search engine to locate the Item. Think about which properties a user is likely to mention in their search query, and include these properties in the Item name and description. These should include the Item model, make, colour, type, purpose, etc.  If you cannot determine a suitable name or description or cannot interpret the image, please return 'Unknown' for both.",
+    "system_prompt_tmplt": "You are a faithful assistant that helps with inventory management. You will receive images of Items that are being placed into storage, and must generate helpful names and descriptions of the main Item in the image. These names and descriptions will be used in future searches, where the user will ask a search engine to locate the Item. Think about which properties a user is likely to mention in their search query, and include these properties in the Item name and description. These should include the Item model, make, colour, type, purpose, etc.  If you cannot determine a suitable name or description or cannot interpret the image, please return 'Unknown' for both. Important: The item name must be at most 30 characters. The description must be at most 200 characters.",
     "human_prompt_tmplt": null,
     "model_id": "us.anthropic.claude-sonnet-4-6",
-    "max_tokens":100,
+    "max_tokens": 100,
     "temp": 0.3,
     "retry_timeout": 1,
-    "retry_limit": 10
+    "retry_limit": 3
 }


### PR DESCRIPTION
This pull request introduces a robust "reask" retry mechanism for handling structured output parsing and validation errors in the `StructuredLangChainHandler`, improving reliability when interacting with LLMs. It also updates the item image generation LLM call to use a new model and stricter prompt constraints, and adds comprehensive tests for the new retry logic. The most important changes are grouped below:

### LLM Structured Output Handling Improvements

* Implements a two-tier retry strategy in `StructuredLangChainHandler`: "reask" for structured output/validation errors (returning the error to the model for self-correction), and naive retry for transport/throttling errors. This ensures that validation and parsing failures are handled gracefully and transparently to the user. [[1]](diffhunk://#diff-ae7120ee65e0dcd58c3baf6084b391a16fa4e318909ab0d71ade10c9efa0569bR14-R31) [[2]](diffhunk://#diff-ae7120ee65e0dcd58c3baf6084b391a16fa4e318909ab0d71ade10c9efa0569bL211-R223) [[3]](diffhunk://#diff-ae7120ee65e0dcd58c3baf6084b391a16fa4e318909ab0d71ade10c9efa0569bL221-R341)
* Adds specific handling for `OutputParserException` in the `extract_item_features_api` endpoint, returning a clear error message and HTTP 500 when the LLM fails to produce valid structured output after all attempts. [[1]](diffhunk://#diff-df4b89f5f945910d50f8ffe6681085a9ff106bf2d73be7816c10bf6b9a29ee43R18) [[2]](diffhunk://#diff-df4b89f5f945910d50f8ffe6681085a9ff106bf2d73be7816c10bf6b9a29ee43R1207-R1209)

### Testing Enhancements

* Adds a comprehensive test suite (`TestStructuredReask`) for the new reask logic, covering scenarios such as recovery from None/validation errors, exhaustion of retries, and accumulation of reask messages. [[1]](diffhunk://#diff-f9edab7fb16007029c5e1c433a6fe91f9b12bd9c4ac449b7069d378c73914adaL10-R11) [[2]](diffhunk://#diff-f9edab7fb16007029c5e1c433a6fe91f9b12bd9c4ac449b7069d378c73914adaR531-R686)

### LLM Call Configuration

* Updates the item image generation LLM call configuration to use the `gemini-3.1-flash-lite-preview` model, enforces stricter name/description length constraints in the system prompt, and reduces the retry limit to 3.

These changes collectively improve the robustness and user feedback of LLM-powered structured extraction, and ensure that model and prompt settings are up-to-date for item image generation.